### PR TITLE
Evita erros ao selecionar unidades fora de período de postagem

### DIFF
--- a/src/app/frequency/frequency.page.html
+++ b/src/app/frequency/frequency.page.html
@@ -113,7 +113,7 @@
       <div class="container-button-frequency">
         <ion-button
           type="submit"
-          [disabled]="!f.valid || (!globalAbsence && !selectedClasses.length)"
+          [disabled]="!f.valid || !classrooms.length || (!globalAbsence && !selectedClasses.length)"
           *ngIf="unities.length"
         >
           Carregar lista de frequência

--- a/src/app/frequency/frequency.page.ts
+++ b/src/app/frequency/frequency.page.ts
@@ -102,12 +102,14 @@ export class FrequencyPage implements OnInit {
                   this.scrollTo('frequency-classroom');
                 },
                 error: (error) => {
+                  this.resetOptions();
                   loader.dismiss();
                   this.messages.showToast(error);
                 },
               });
           },
           error: (error) => {
+            this.resetOptions();
             loader.dismiss();
             this.messages.showToast(error);
           },
@@ -232,6 +234,13 @@ export class FrequencyPage implements OnInit {
     this.classroomId = undefined;
     this.disciplineId = undefined;
     this.selectedClasses = [];
+  }
+
+  resetOptions() {
+    this.classrooms = [];
+    this.disciplines = [];
+    this.classes= [];
+    this.resetSelectedValues();
   }
 
   updateSelectedClasses(selectedClass: any) {

--- a/src/app/new-content-record-form/new-content-record-form.page.html
+++ b/src/app/new-content-record-form/new-content-record-form.page.html
@@ -94,7 +94,11 @@
         ></ion-datetime>
       </div>
 
-      <ion-button expand="block" type="submit" [disabled]="!f.valid">
+      <ion-button
+        expand="block"
+        type="submit"
+        [disabled]="!f.valid || !classrooms.length"
+      >
         Avançar
       </ion-button>
     </div>

--- a/src/app/new-content-record-form/new-content-record-form.page.ts
+++ b/src/app/new-content-record-form/new-content-record-form.page.ts
@@ -52,6 +52,7 @@ export class NewContentRecordFormPage implements OnInit {
 
   onChangeUnity() {
     if (!this.unityId) {
+      this.resetSelectedValues();
       return;
     }
 
@@ -61,6 +62,8 @@ export class NewContentRecordFormPage implements OnInit {
         this.classrooms = classrooms.data;
       },
       error: (err: any) => {
+        this.classrooms = [];
+        this.disciplines = [];
         console.log(err);
       },
     });

--- a/src/app/new-content-record-form/new-content-record-form.page.ts
+++ b/src/app/new-content-record-form/new-content-record-form.page.ts
@@ -6,6 +6,7 @@ import { Unity } from '../data/unity.interface';
 import { ClassroomsService } from '../services/classrooms';
 import { DisciplinesService } from '../services/disciplines';
 import { UtilsService } from '../services/utils';
+import { MessagesService } from "../services/messages";
 
 @Component({
   selector: 'app-new-content-record-form',
@@ -27,6 +28,7 @@ export class NewContentRecordFormPage implements OnInit {
     private route: ActivatedRoute,
     private classroomsService: ClassroomsService,
     private disciplinesService: DisciplinesService,
+    private messages: MessagesService,
     private router: Router,
     private utilsService: UtilsService,
   ) {}
@@ -64,6 +66,7 @@ export class NewContentRecordFormPage implements OnInit {
       error: (err: any) => {
         this.classrooms = [];
         this.disciplines = [];
+        this.messages.showError(err, 'Erro');
         console.log(err);
       },
     });

--- a/src/app/tab2/tab2.page.ts
+++ b/src/app/tab2/tab2.page.ts
@@ -34,6 +34,14 @@ export class Tab2Page {
     await this.sync.isSyncDelayed();
 
     this.route.params.subscribe(() => {
+      this.contentDays = [];
+      this.unities = [];
+      this.lessonPlans = [];
+      this.contentRecords = [];
+      this.teachingPlans = { unities: [] };
+      this.classrooms = [];
+      this.currentDate = new Date();
+
       this.loadContentDays();
     });
   }


### PR DESCRIPTION
Ao tentar fazer algum lançamento para uma escola fora de período de postagem, o aplicativo estava se "perdendo" em limpar as opções de seleção permitindo que o usuário avançasse nas etapas de lançamento mesmo a escola estando fora do período de postagem.

Resolve este problema na tela de frequência e conteúdos.