### PR TITLE
Corrige erro de sincronização com URL null em cold start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "i-diario",
-  "version": "1.2.19",
+  "version": "1.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "i-diario",
-      "version": "1.2.19",
+      "version": "1.2.23",
       "dependencies": {
         "@angular/animations": "^18",
         "@angular/common": "^18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i-diario",
-  "version": "1.2.19",
+  "version": "1.2.23",
   "author": "Portábilis",
   "homepage": "https://portabilis.com.br",
   "scripts": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,4 @@
 import { Component } from '@angular/core';
-import { Platform } from '@ionic/angular';
-import { StorageService } from './services/storage.service';
 
 @Component({
   selector: 'app-root',
@@ -8,15 +6,4 @@ import { StorageService } from './services/storage.service';
   styleUrls: ['app.component.scss'],
   standalone: false,
 })
-export class AppComponent {
-  constructor(
-    private storage: StorageService,
-    private platform: Platform,
-  ) {}
-
-  async ngOnInit() {
-    this.platform.ready().then(async () => {
-      await this.storage.init();
-    });
-  }
-}
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,8 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { APP_INITIALIZER } from '@angular/core';
+import { StorageService } from './services/storage.service';
 import { IonicStorageModule } from '@ionic/storage-angular';
 import { ApiService } from './services/api';
 import { ConnectionService } from './services/connection';
@@ -60,6 +62,12 @@ import { DailyFrequencyStudentService } from './services/daily_frequency_student
     IonicStorageModule.forRoot(),
   ],
   providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (storage: StorageService) => () => storage.init(),
+      deps: [StorageService],
+      multi: true,
+    },
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -4,17 +4,15 @@ import { environment } from 'src/environments/environment';
 
 @Injectable()
 export class ApiService {
-  serverUrl: string = '';
+  constructor(private storage: StorageService) {}
 
-  constructor(private storage: StorageService) {
-    this.storage.get('serverUrl').then((serverUrl) => {
-      this.serverUrl = serverUrl;
-    });
+  get serverUrl(): string {
+    return this.storage.serverUrl;
   }
 
   setServerUrl(serverUrl: string) {
     this.storage.set('serverUrl', serverUrl);
-    this.serverUrl = serverUrl;
+    this.storage.serverUrl = serverUrl;
   }
 
   getTeacherClassroomsUrl() {

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -6,6 +6,7 @@ import { Storage } from '@ionic/storage-angular';
 })
 export class StorageService {
   private initialized = false;
+  public serverUrl: string = '';
 
   constructor(private storage: Storage) {}
 
@@ -17,6 +18,7 @@ export class StorageService {
     this.initialized = true;
     await this.storage.create();
     await this.initializeDefaultData();
+    this.serverUrl = (await this.storage.get('serverUrl')) || '';
   }
 
   // TODO verificar


### PR DESCRIPTION
closes: https://github.com/portabilis/board/issues/7337

### 🐛 Problema

Em dispositivos Xiaomi com Android 13 (MIUI), o app exibia o erro `Http failure response for https://localhost/null/api/v2/diario-de-frequencia.json 404 OK` ao sincronizar.

O `ApiService` carregava a `serverUrl` de forma assíncrona no construtor, sem garantir que o `StorageService` estivesse inicializado. Em dispositivos com gerenciamento agressivo de memória, o app fazia cold start e o `storage.get('serverUrl')` retornava `null` antes da inicialização, gerando URLs como `https://localhost/null/api/v2/...`.

Como o usuário já estava logado, o app pulava a tela de login (onde a `serverUrl` é definida), resultando em um loop onde a sincronização sempre falhava — mesmo reinstalando o app.

### 🔧 Solução Implementada

1. Move a inicialização do storage para `APP_INITIALIZER`, garantindo que esteja pronto antes de qualquer serviço
2. Centraliza a `serverUrl` no `StorageService`, eliminando a leitura assíncrona no construtor do `ApiService`
3. Adiciona proteção contra `null` com fallback para string vazia

### 📁 Arquivos alterados

- `app.module.ts` — Adiciona `APP_INITIALIZER` para inicializar o storage antes de tudo
- `app.component.ts` — Remove `storage.init()` duplicado
- `api.ts` — Usa getter que lê `serverUrl` direto do `StorageService`
- `storage.service.ts` — Carrega `serverUrl` durante o `init()`
